### PR TITLE
Integrate task API and react-query

### DIFF
--- a/src/components/custom/ResizableFloatingWindow/GroupTodo/GroupTodo.tsx
+++ b/src/components/custom/ResizableFloatingWindow/GroupTodo/GroupTodo.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import {
 	Calendar,
 	Edit3,
@@ -35,6 +36,8 @@ import {
 	DropdownItem,
 	DragHandle,
 } from "../PersonalTodo/PersonalTodo.styled";
+import { taskAPI, GroupTodoUpdateRequest } from "@/services/taskAPI";
+import { Task as ApiTask, TaskStatus } from "@/types/task";
 
 /* ---------- types ---------- */
 type Task = {
@@ -51,9 +54,36 @@ type Task = {
 type Props = { groupId?: string; groupName?: string };
 
 /* ---------- utils ---------- */
-function getGroupKey(groupId: string) {
-	return `devchat_group_tasks_${groupId}`;
+function convertApiTaskToLocalTask(apiTask: ApiTask): Task {
+	try {
+		return {
+			id: apiTask.id,
+			name: apiTask.name,
+			description: apiTask.description || undefined,
+			priority: apiTask.priority,
+			status: apiTask.status,
+			dueDate: apiTask.dueDate || undefined,
+			createdAt: new Date(apiTask.createdAt).getTime(),
+			done: apiTask.status === TaskStatus.DONE,
+		};
+	} catch (error) {
+		console.warn("Error converting API task:", error, apiTask);
+		// Fallback with safe defaults
+		return {
+			id: apiTask.id || "unknown",
+			name: apiTask.name || "Untitled Task",
+			description: apiTask.description || undefined,
+			priority: apiTask.priority || 3,
+			status: apiTask.status || TaskStatus.TODO,
+			dueDate: apiTask.dueDate || undefined,
+			createdAt: apiTask.createdAt
+				? new Date(apiTask.createdAt).getTime()
+				: Date.now(),
+			done: apiTask.status === TaskStatus.DONE,
+		};
+	}
 }
+
 function isoToDatetimeLocal(iso?: string) {
 	if (!iso) return "";
 	const d = new Date(iso);
@@ -76,8 +106,46 @@ function daysDiffFromNow(iso?: string) {
 export default function GroupTodo({ groupId, groupName }: Props) {
 	const gid = groupId ?? "unknown";
 	const gname = groupName ?? "Group";
+	const queryClient = useQueryClient();
 
-	const STORAGE_KEY = getGroupKey(gid);
+	// Fetch tasks from API
+	const {
+		data: apiTasksData,
+		isLoading,
+		isError,
+		error,
+	} = useQuery({
+		queryKey: ["userTasks", gid],
+		queryFn: () => taskAPI.getUserTasksByGroup(gid),
+		enabled: !!groupId && groupId !== "unknown",
+		refetchOnWindowFocus: false,
+	});
+
+	// Convert API tasks to local task format
+	const apiTasks = Array.isArray(apiTasksData?.data)
+		? apiTasksData.data
+		: Array.isArray(apiTasksData)
+			? apiTasksData
+			: [];
+	const convertedTasks = apiTasks.map(convertApiTaskToLocalTask);
+
+	// Mutations for task operations
+	const updateTaskMutation = useMutation({
+		mutationFn: ({ taskId, data }: { taskId: string; data: any }) =>
+			taskAPI.updateTask(gid, taskId, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["userTasks", gid] });
+		},
+	});
+
+	const deleteTaskMutation = useMutation({
+		mutationFn: (taskId: string) => taskAPI.deleteTask(gid, taskId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["userTasks", gid] });
+		},
+	});
+
+	// Fallback sample tasks for when no groupId or API fails
 	const SAMPLE_TASKS: Task[] = [
 		{
 			id: `g-${gid}-1`,
@@ -101,26 +169,20 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 		},
 	];
 
-	const [tasks, setTasks] = useState<Task[]>(() => {
-		try {
-			const raw =
-				typeof window !== "undefined"
-					? localStorage.getItem(STORAGE_KEY)
-					: null;
-			return raw ? JSON.parse(raw) : SAMPLE_TASKS;
-		} catch (e) {
-			console.warn("Failed to parse group tasks", e);
-			return SAMPLE_TASKS;
+	// Local state for sample tasks when API is not available
+	const [sampleTasks, setSampleTasks] = useState<Task[]>(() => {
+		if (groupId && groupId !== "unknown") {
+			// For real groups, start with empty array and let API load
+			return [];
 		}
+		// For sample/unknown groups, use sample data
+		return SAMPLE_TASKS;
 	});
 
-	useEffect(() => {
-		try {
-			if (groupId) localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
-		} catch (e) {
-			console.log("Failed to save group tasks", e);
-		}
-	}, [tasks, STORAGE_KEY, groupId]);
+	// Use API data if available, otherwise use sample data
+	const isUsingApiData =
+		!isError && apiTasks.length > 0 && groupId !== "unknown";
+	const tasks = isUsingApiData ? convertedTasks : sampleTasks;
 
 	/* ---------- inline edit ---------- */
 	const [editingId, setEditingId] = useState<string | null>(null);
@@ -139,21 +201,80 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 	function saveInlineEdit(id: string) {
 		const text = (editFields.name ?? "").trim();
 		if (!text) return;
-		setTasks((s) =>
-			s.map((x) => (x.id === id ? { ...x, ...(editFields as Task) } : x)),
-		);
+
+		if (isUsingApiData) {
+			// Update via API - use correct field names
+			const updateData: GroupTodoUpdateRequest = {};
+			if (editFields.name !== undefined) updateData.name = editFields.name;
+			if (editFields.description !== undefined)
+				updateData.description = editFields.description || "";
+			if (editFields.status !== undefined)
+				updateData.status = editFields.status;
+			if (editFields.priority !== undefined)
+				updateData.priority = editFields.priority;
+			if (editFields.dueDate !== undefined)
+				updateData.dueDate = editFields.dueDate;
+
+			updateTaskMutation.mutate(
+				{ taskId: id, data: updateData },
+				{
+					onError: (error) => {
+						console.error("Failed to update task:", error);
+						alert("Failed to update task. Please try again.");
+					},
+				},
+			);
+		} else {
+			// Update local state for sample data
+			setSampleTasks((s) =>
+				s.map((x) => (x.id === id ? { ...x, ...(editFields as Task) } : x)),
+			);
+		}
+
 		setEditingId(null);
 		setEditFields({});
 	}
 
 	/* ---------- toggle / delete ---------- */
 	function toggleDone(id: string) {
-		setTasks((s) => s.map((x) => (x.id === id ? { ...x, done: !x.done } : x)));
+		if (isUsingApiData) {
+			const currentTask = tasks.find((t) => t.id === id);
+			if (currentTask) {
+				const newStatus = currentTask.done ? TaskStatus.TODO : TaskStatus.DONE;
+				updateTaskMutation.mutate(
+					{
+						taskId: id,
+						data: { status: newStatus },
+					},
+					{
+						onError: (error) => {
+							console.error("Failed to toggle task status:", error);
+							alert("Failed to update task status. Please try again.");
+						},
+					},
+				);
+			}
+		} else {
+			setSampleTasks((s) =>
+				s.map((x) => (x.id === id ? { ...x, done: !x.done } : x)),
+			);
+		}
 	}
+
 	function deleteTask(id: string) {
 		const ok = window.confirm("Are you sure you want to delete this task?");
 		if (!ok) return;
-		setTasks((s) => s.filter((x) => x.id !== id));
+
+		if (isUsingApiData) {
+			deleteTaskMutation.mutate(id, {
+				onError: (error) => {
+					console.error("Failed to delete task:", error);
+					alert("Failed to delete task. Please try again.");
+				},
+			});
+		} else {
+			setSampleTasks((s) => s.filter((x) => x.id !== id));
+		}
 	}
 
 	/* ---------- drag & drop reorder (match PersonalTodo behavior) ---------- */
@@ -191,18 +312,21 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 			return;
 		}
 
-		setTasks((s) => {
-			const arr = s.slice();
-			const fromIndex = arr.findIndex((x) => x.id === fromId);
-			let toIndex = arr.findIndex((x) => x.id === toId);
-			if (fromIndex === -1 || toIndex === -1) return s;
+		if (!isUsingApiData) {
+			// Only allow reordering for sample data
+			setSampleTasks((s) => {
+				const arr = s.slice();
+				const fromIndex = arr.findIndex((x) => x.id === fromId);
+				let toIndex = arr.findIndex((x) => x.id === toId);
+				if (fromIndex === -1 || toIndex === -1) return s;
 
-			const [item] = arr.splice(fromIndex, 1);
-			// Adjust toIndex when moving downward
-			if (fromIndex < toIndex) toIndex = toIndex - 1;
-			arr.splice(toIndex, 0, item);
-			return arr;
-		});
+				const [item] = arr.splice(fromIndex, 1);
+				// Adjust toIndex when moving downward
+				if (fromIndex < toIndex) toIndex = toIndex - 1;
+				arr.splice(toIndex, 0, item);
+				return arr;
+			});
+		}
 
 		cleanupDrag();
 	}
@@ -225,12 +349,35 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 				<div style={{ fontSize: 14 }}>
 					Tasks for group <strong>{gname}</strong>
 				</div>
-				<Note>Edit / reorder / delete only (no create)</Note>
+				<Note>
+					{groupId === "unknown" || !groupId
+						? "No group selected - showing sample tasks"
+						: isLoading
+							? "Loading tasks..."
+							: isError
+								? `Error loading tasks: ${error?.message || "Unknown error"}`
+								: isUsingApiData
+									? `Loaded from API - changes will sync with server ${
+											updateTaskMutation.isPending ||
+											deleteTaskMutation.isPending
+												? "(Saving...)"
+												: ""
+										}`
+									: "Edit / reorder / delete only (no create)"}
+				</Note>
 			</Header>
 
 			<TaskList>
-				{tasks.length === 0 ? (
-					<div style={{ color: "#64748b" }}>No tasks in this group.</div>
+				{isLoading ? (
+					<div
+						style={{ color: "#64748b", textAlign: "center", padding: "20px" }}
+					>
+						Loading tasks...
+					</div>
+				) : tasks.length === 0 ? (
+					<div style={{ color: "#64748b" }}>
+						{isError ? "Failed to load tasks." : "No tasks in this group."}
+					</div>
 				) : (
 					tasks
 						.slice()
@@ -288,6 +435,11 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 												display: "flex",
 												justifyContent: "space-between",
 												gap: 12,
+												opacity:
+													updateTaskMutation.isPending ||
+													deleteTaskMutation.isPending
+														? 0.6
+														: 1,
 											}}
 										>
 											<div style={{ flex: 1 }}>
@@ -456,19 +608,28 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 												<div style={{ marginTop: 10, display: "flex", gap: 8 }}>
 													<button
 														onClick={() => saveInlineEdit(t.id)}
+														disabled={updateTaskMutation.isPending}
 														style={{
-															background: "#16a34a",
+															background: updateTaskMutation.isPending
+																? "#94a3b8"
+																: "#16a34a",
 															color: "white",
 															padding: 8,
 															borderRadius: 8,
 															border: "none",
-															cursor: "pointer",
+															cursor: updateTaskMutation.isPending
+																? "not-allowed"
+																: "pointer",
 															display: "flex",
 															gap: 8,
 															alignItems: "center",
+															opacity: updateTaskMutation.isPending ? 0.6 : 1,
 														}}
 													>
-														<Check size={14} /> Save
+														<Check size={14} />
+														{updateTaskMutation.isPending
+															? "Saving..."
+															: "Save"}
 													</button>
 													<button
 														onClick={cancelInlineEdit}
@@ -518,8 +679,17 @@ export default function GroupTodo({ groupId, groupName }: Props) {
 															setOpenDropdownFor(null);
 															deleteTask(t.id);
 														}}
+														style={{
+															opacity: deleteTaskMutation.isPending ? 0.6 : 1,
+															pointerEvents: deleteTaskMutation.isPending
+																? "none"
+																: "auto",
+														}}
 													>
-														<Trash2 size={14} /> Delete
+														<Trash2 size={14} />
+														{deleteTaskMutation.isPending
+															? "Deleting..."
+															: "Delete"}
 													</DropdownItem>
 												</Dropdown>
 											)}

--- a/src/components/custom/RightPanel/TaskGroup/TaskGroup.tsx
+++ b/src/components/custom/RightPanel/TaskGroup/TaskGroup.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import {
 	SquareCheckBig,
 	X,
@@ -18,6 +19,13 @@ import {
 	Loader,
 } from "lucide-react";
 import * as S from "./TaskGroup.styled";
+import {
+	taskAPI,
+	CreateTaskRequest,
+	UpdateTaskRequest,
+} from "@/services/taskAPI";
+import { Task as ApiTask, TaskStatus, TaskPriority } from "@/types/task";
+import { membersGroup } from "@/services/userGroupAPI";
 
 type Task = {
 	id: string;
@@ -27,7 +35,98 @@ type Task = {
 	priority: "Low" | "Medium" | "High";
 	dueDate: string;
 	assignedTo: string;
-	createdBy: string;
+};
+
+type GroupMember = {
+	id: string;
+	username: string;
+	email: string;
+	role?: string;
+	joined_at?: string;
+};
+
+// Conversion functions between API and local Task types
+const convertApiTaskToLocal = (apiTask: ApiTask): Task => {
+	const statusMap: Record<TaskStatus, Task["status"]> = {
+		[TaskStatus.TODO]: "To Do",
+		[TaskStatus.IN_PROGRESS]: "In Progress",
+		[TaskStatus.DONE]: "Done",
+	};
+
+	const priorityMap: Record<TaskPriority, Task["priority"]> = {
+		[TaskPriority.LOW]: "Low",
+		[TaskPriority.MEDIUM]: "Medium",
+		[TaskPriority.HIGH]: "High",
+	};
+
+	return {
+		id: apiTask.id,
+		name: apiTask.name,
+		description: apiTask.description || "",
+		status: statusMap[apiTask.status] || "To Do",
+		priority: priorityMap[apiTask.priority] || "Medium",
+		dueDate: apiTask.dueDate || new Date().toISOString().split("T")[0],
+		assignedTo: apiTask.assignee?.id || "",
+	};
+};
+
+const convertLocalToApiCreate = (
+	localTask: Omit<Task, "id">,
+): CreateTaskRequest => {
+	const statusMap: Record<Task["status"], TaskStatus> = {
+		Open: TaskStatus.TODO,
+		"To Do": TaskStatus.TODO,
+		"In Progress": TaskStatus.IN_PROGRESS,
+		Done: TaskStatus.DONE,
+	};
+
+	const priorityMap: Record<Task["priority"], TaskPriority> = {
+		Low: TaskPriority.LOW,
+		Medium: TaskPriority.MEDIUM,
+		High: TaskPriority.HIGH,
+	};
+
+	return {
+		name: localTask.name,
+		description: localTask.description,
+		status: statusMap[localTask.status],
+		priority: priorityMap[localTask.priority],
+		dueDate: localTask.dueDate
+			? new Date(localTask.dueDate).toISOString()
+			: undefined,
+		assigneeId:
+			localTask.assignedTo && localTask.assignedTo.trim() !== ""
+				? localTask.assignedTo
+				: undefined,
+	};
+};
+
+const convertLocalToApiUpdate = (
+	localTask: Partial<Task>,
+): UpdateTaskRequest => {
+	const statusMap: Record<Task["status"], TaskStatus> = {
+		Open: TaskStatus.TODO,
+		"To Do": TaskStatus.TODO,
+		"In Progress": TaskStatus.IN_PROGRESS,
+		Done: TaskStatus.DONE,
+	};
+
+	const priorityMap: Record<Task["priority"], TaskPriority> = {
+		Low: TaskPriority.LOW,
+		Medium: TaskPriority.MEDIUM,
+		High: TaskPriority.HIGH,
+	};
+
+	return {
+		name: localTask.name,
+		description: localTask.description,
+		status: localTask.status ? statusMap[localTask.status] : undefined,
+		priority: localTask.priority ? priorityMap[localTask.priority] : undefined,
+		dueDate: localTask.dueDate
+			? new Date(localTask.dueDate).toISOString()
+			: undefined,
+		assigneeId: localTask.assignedTo || undefined,
+	};
 };
 
 type AlertType = "success" | "warning" | "error";
@@ -407,53 +506,85 @@ const Dialog: React.FC<{
 		</S.DialogOverlay>
 	);
 };
-type TaskGroupProps = {
+export type TaskGroupProps = {
 	onClose?: () => void;
+	groupId?: string;
 };
 
-export default function TaskGroup({ onClose }: TaskGroupProps) {
-	const [tasks, setTasks] = useState<Task[]>([
-		{
-			id: "1",
-			name: "Implement user authentication",
-			description: "Create login/register functionality with JWT tokens",
-			status: "Open",
-			priority: "Low",
-			dueDate: "2026-01-01",
-			assignedTo: "John Doe",
-			createdBy: "Alice Johnson",
+export default function TaskGroup({ onClose, groupId }: TaskGroupProps) {
+	const queryClient = useQueryClient();
+
+	// Fetch tasks from API
+	const {
+		data: apiTasksData,
+		isLoading,
+		isError,
+		error,
+	} = useQuery({
+		queryKey: ["tasks", groupId],
+		queryFn: () => taskAPI.getTasks(groupId!, { page: 1, limit: 100 }),
+		enabled: !!groupId,
+		refetchOnWindowFocus: false,
+	});
+
+	// Fetch group members for assignee options
+	const { data: membersData, isLoading: membersLoading } = useQuery({
+		queryKey: ["groupMembers", groupId],
+		queryFn: () => membersGroup(groupId!, 1, 100),
+		enabled: !!groupId,
+		refetchOnWindowFocus: false,
+	});
+
+	const groupMembers = membersData?.data || [];
+
+	// Convert API tasks to local format
+	const apiTasks = apiTasksData?.data || [];
+	const tasks = apiTasks.map(convertApiTaskToLocal);
+
+	const displayTasks = tasks;
+
+	// Mutations for CRUD operations
+	const createTaskMutation = useMutation({
+		mutationFn: (data: CreateTaskRequest) => taskAPI.createTask(groupId!, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["tasks", groupId] });
+			fireAlert("success", "Task created successfully");
 		},
-		{
-			id: "2",
-			name: "Design database schema",
-			description: "Create ERD and define relationships between entities",
-			status: "To Do",
-			priority: "Medium",
-			dueDate: "2025-11-16",
-			assignedTo: "Alice Johnson",
-			createdBy: "John Doe",
+		onError: (error) => {
+			console.error("Failed to create task:", error);
+			fireAlert("error", "Failed to create task. Please try again.");
 		},
-		{
-			id: "3",
-			name: "Implement user authentication",
-			description: "Create login/register functionality with JWT tokens",
-			status: "In Progress",
-			priority: "High",
-			dueDate: "2026-01-01",
-			assignedTo: "John Doe",
-			createdBy: "Alice Johnson",
+	});
+
+	const updateTaskMutation = useMutation({
+		mutationFn: ({
+			taskId,
+			data,
+		}: {
+			taskId: string;
+			data: UpdateTaskRequest;
+		}) => taskAPI.updateTask(groupId!, taskId, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["tasks", groupId] });
+			fireAlert("success", "Task updated successfully");
 		},
-		{
-			id: "4",
-			name: "Design database schema",
-			description: "Create ERD and define relationships between entities",
-			status: "Done",
-			priority: "Medium",
-			dueDate: "2025-11-16",
-			assignedTo: "Alice Johnson",
-			createdBy: "John Doe",
+		onError: (error) => {
+			console.error("Failed to update task:", error);
+			fireAlert("error", "Failed to update task. Please try again.");
 		},
-	]);
+	});
+
+	const deleteTaskMutation = useMutation({
+		mutationFn: (taskId: string) => taskAPI.deleteTask(groupId!, taskId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["tasks", groupId] });
+			fireAlert("success", "Task deleted successfully");
+		},
+		onError: (error) => {
+			console.error("Failed to delete task:", error);
+			fireAlert("error", "Failed to delete task. Please try again.");
+		},
+	});
 
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [isUpdateOpen, setIsUpdateOpen] = useState(false);
@@ -467,7 +598,6 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 		priority: "Medium" as Task["priority"],
 		dueDate: "",
 		assignedTo: "",
-		createdBy: "John Doe",
 	});
 
 	const statusOptions = [
@@ -483,17 +613,10 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 		{ value: "High", label: "High" },
 	];
 
-	const assigneeOptions = [
-		{ value: "John Doe", label: "John Doe" },
-		{ value: "Alice Johnson", label: "Alice Johnson" },
-		{ value: "Bob Smith", label: "Bob Smith" },
-	];
-
-	const createdByOptions = [
-		{ value: "John Doe", label: "John Doe (john.doe@example.com)" },
-		{ value: "Alice Johnson", label: "Alice Johnson" },
-		{ value: "Bob Smith", label: "Bob Smith" },
-	];
+	const assigneeOptions = groupMembers.map((member: GroupMember) => ({
+		value: member.id,
+		label: `${member.username} (${member.email})`,
+	}));
 
 	const resetForm = () => {
 		setFormData({
@@ -503,51 +626,64 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 			priority: "Medium",
 			dueDate: "",
 			assignedTo: "",
-			createdBy: "John Doe",
 		});
 	};
 
 	const handleCreate = () => {
+		if (!groupId) {
+			fireAlert("error", "No group selected");
+			return;
+		}
 		if (!formData.name.trim()) {
 			fireAlert("warning", "Task name is required");
 			return;
 		}
 
-		const newTask: Task = {
-			id: Date.now().toString(),
-			...formData,
-		};
-
-		setTasks([...tasks, newTask]);
-		fireAlert("success", "Task created successfully");
-		setIsCreateOpen(false);
-		resetForm();
+		const createData = convertLocalToApiCreate(formData);
+		createTaskMutation.mutate(createData, {
+			onSuccess: () => {
+				setIsCreateOpen(false);
+				resetForm();
+			},
+		});
 	};
 
 	const handleUpdate = () => {
 		if (!selectedTask) return;
+		if (!groupId) {
+			fireAlert("error", "No group selected");
+			return;
+		}
 		if (!formData.name.trim()) {
 			fireAlert("warning", "Task name is required");
 			return;
 		}
 
-		setTasks(
-			tasks.map((task) =>
-				task.id === selectedTask.id ? { ...task, ...formData } : task,
-			),
+		const updateData = convertLocalToApiUpdate(formData);
+		updateTaskMutation.mutate(
+			{ taskId: selectedTask.id, data: updateData },
+			{
+				onSuccess: () => {
+					setIsUpdateOpen(false);
+					setSelectedTask(null);
+					resetForm();
+				},
+			},
 		);
-		fireAlert("success", "Task updated successfully");
-		setIsUpdateOpen(false);
-		setSelectedTask(null);
-		resetForm();
 	};
 
 	const handleDelete = () => {
 		if (!selectedTask) return;
-		setTasks(tasks.filter((task) => task.id !== selectedTask.id));
-		fireAlert("success", "Task deleted successfully");
-		setIsDeleteOpen(false);
-		setSelectedTask(null);
+		if (!groupId) {
+			fireAlert("error", "No group selected");
+			return;
+		}
+		deleteTaskMutation.mutate(selectedTask.id, {
+			onSuccess: () => {
+				setIsDeleteOpen(false);
+				setSelectedTask(null);
+			},
+		});
 	};
 
 	const openUpdateDialog = (task: Task) => {
@@ -559,7 +695,6 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 			priority: task.priority,
 			dueDate: task.dueDate,
 			assignedTo: task.assignedTo,
-			createdBy: task.createdBy,
 		});
 		setIsUpdateOpen(true);
 	};
@@ -567,6 +702,12 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 	const openDeleteDialog = (task: Task) => {
 		setSelectedTask(task);
 		setIsDeleteOpen(true);
+	};
+
+	const getAssigneeDisplayName = (assigneeId: string) => {
+		if (!assigneeId) return "Unassigned";
+		const member = groupMembers.find((m: GroupMember) => m.id === assigneeId);
+		return member ? member.username : "Unknown User";
 	};
 
 	const getPriorityColor = (priority: string) => {
@@ -657,55 +798,103 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 						<Plus size={16} /> Create Task{" "}
 					</S.Button>
 				</S.HeaderWrapper>
-				{tasks.map((task) => {
-					const statusColors = getStatusColor(task.status);
-					const priorityColors = getPriorityColor(task.priority);
+				{isLoading && (
+					<S.TaskCard>
+						<div style={{ textAlign: "center", padding: "20px" }}>
+							<Loader
+								size={20}
+								style={{ animation: "spin 1s linear infinite" }}
+							/>
+							<div style={{ marginTop: "10px" }}>Loading tasks...</div>
+						</div>
+					</S.TaskCard>
+				)}
+				{isError && (
+					<S.TaskCard>
+						<div
+							style={{ textAlign: "center", padding: "20px", color: "#D83232" }}
+						>
+							Error loading tasks: {error?.message || "Unknown error"}
+						</div>
+					</S.TaskCard>
+				)}
+				{!groupId && (
+					<S.TaskCard>
+						<div
+							style={{ textAlign: "center", padding: "40px", color: "#6b7280" }}
+						>
+							<div style={{ fontSize: "18px", marginBottom: "8px" }}>
+								No group selected
+							</div>
+							<div style={{ fontSize: "14px" }}>
+								Please select a group to view tasks
+							</div>
+						</div>
+					</S.TaskCard>
+				)}
+				{groupId && !isLoading && displayTasks.length === 0 && !isError && (
+					<S.TaskCard>
+						<div
+							style={{ textAlign: "center", padding: "40px", color: "#6b7280" }}
+						>
+							<div style={{ fontSize: "18px", marginBottom: "8px" }}>
+								No tasks yet
+							</div>
+							<div style={{ fontSize: "14px" }}>
+								Create your first task to get started
+							</div>
+						</div>
+					</S.TaskCard>
+				)}
+				{groupId &&
+					!isLoading &&
+					displayTasks.length > 0 &&
+					displayTasks.map((task) => {
+						const statusColors = getStatusColor(task.status);
+						const priorityColors = getPriorityColor(task.priority);
 
-					return (
-						<S.TaskCard key={task.id}>
-							<S.TaskHeader>
-								<S.TaskTitle>{task.name}</S.TaskTitle>
-								<S.TaskActions>
-									<Edit2
-										size={18}
-										style={{ cursor: "pointer", color: "#608BC1" }}
-										onClick={() => openUpdateDialog(task)}
-									/>
-									<Trash2
-										size={18}
-										style={{ cursor: "pointer", color: "#D83232" }}
-										onClick={() => openDeleteDialog(task)}
-									/>
-								</S.TaskActions>
-							</S.TaskHeader>
+						return (
+							<S.TaskCard key={task.id}>
+								<S.TaskHeader>
+									<S.TaskTitle>{task.name}</S.TaskTitle>
+									<S.TaskActions>
+										<Edit2
+											size={18}
+											style={{ cursor: "pointer", color: "#608BC1" }}
+											onClick={() => openUpdateDialog(task)}
+										/>
+										<Trash2
+											size={18}
+											style={{ cursor: "pointer", color: "#D83232" }}
+											onClick={() => openDeleteDialog(task)}
+										/>
+									</S.TaskActions>
+								</S.TaskHeader>
 
-							<S.TaskDescription>{task.description}</S.TaskDescription>
+								<S.TaskDescription>{task.description}</S.TaskDescription>
 
-							<S.TaskBadges>
-								<S.Badge bg={statusColors.bg} color={statusColors.text}>
-									{getStatusIcon(task.status)}
-									{task.status}
-								</S.Badge>
-								<S.Badge bg={priorityColors.bg} color={priorityColors.text}>
-									{getPriorityIcon(task.priority)}
-									{task.priority}
-								</S.Badge>
-							</S.TaskBadges>
+								<S.TaskBadges>
+									<S.Badge bg={statusColors.bg} color={statusColors.text}>
+										{getStatusIcon(task.status)}
+										{task.status}
+									</S.Badge>
+									<S.Badge bg={priorityColors.bg} color={priorityColors.text}>
+										{getPriorityIcon(task.priority)}
+										{task.priority}
+									</S.Badge>
+								</S.TaskBadges>
 
-							<S.TaskMeta>
-								<S.MetaItem>
-									<User size={14} /> {task.assignedTo}
-								</S.MetaItem>
-								<S.MetaItem>
-									<User size={14} /> Created by {task.createdBy}
-								</S.MetaItem>
-								<S.MetaItem>
-									<Calendar size={14} /> {formatDate(task.dueDate)}
-								</S.MetaItem>
-							</S.TaskMeta>
-						</S.TaskCard>
-					);
-				})}
+								<S.TaskMeta>
+									<S.MetaItem>
+										<User size={14} /> {getAssigneeDisplayName(task.assignedTo)}
+									</S.MetaItem>
+									<S.MetaItem>
+										<Calendar size={14} /> {formatDate(task.dueDate)}
+									</S.MetaItem>
+								</S.TaskMeta>
+							</S.TaskCard>
+						);
+					})}
 			</S.ContentArea>
 
 			<Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
@@ -774,19 +963,6 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 						</S.FormGroup>
 
 						<S.FormGroup>
-							<S.Label>
-								Created By <span style={{ color: "#D83232" }}>*</span>
-							</S.Label>
-							<CustomSelect
-								value={formData.createdBy}
-								onChange={(value) =>
-									setFormData({ ...formData, createdBy: value })
-								}
-								options={createdByOptions}
-							/>
-						</S.FormGroup>
-
-						<S.FormGroup>
 							<S.Label>Assign To</S.Label>
 							<CustomSelect
 								value={formData.assignedTo}
@@ -794,17 +970,28 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 									setFormData({ ...formData, assignedTo: value })
 								}
 								options={assigneeOptions}
-								placeholder="Select assignee..."
+								placeholder={
+									membersLoading ? "Loading members..." : "Select assignee..."
+								}
+								disabled={membersLoading}
 							/>
 						</S.FormGroup>
 					</S.DialogBody>
 
 					<S.DialogFooter>
-						<S.Button variant="ghost" onClick={() => setIsCreateOpen(false)}>
+						<S.Button
+							variant="ghost"
+							onClick={() => setIsCreateOpen(false)}
+							disabled={createTaskMutation.isPending}
+						>
 							Cancel
 						</S.Button>
-						<S.Button variant="primary" onClick={handleCreate}>
-							Create Task
+						<S.Button
+							variant="primary"
+							onClick={handleCreate}
+							disabled={createTaskMutation.isPending}
+						>
+							{createTaskMutation.isPending ? "Creating..." : "Create Task"}
 						</S.Button>
 					</S.DialogFooter>
 				</S.DialogContent>
@@ -857,7 +1044,6 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 											})
 										}
 										options={statusOptions}
-										disabled
 									/>
 								</S.FormGroup>
 							</S.FormColumn>
@@ -894,11 +1080,6 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 						</S.FormGroup>
 
 						<S.FormGroup>
-							<S.Label>Created By</S.Label>
-							<S.Input value={formData.createdBy} disabled />
-						</S.FormGroup>
-
-						<S.FormGroup>
 							<S.Label>
 								Assign To <span style={{ color: "#D83232" }}>*</span>
 							</S.Label>
@@ -908,17 +1089,28 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 									setFormData({ ...formData, assignedTo: value })
 								}
 								options={assigneeOptions}
-								placeholder="Select assignee..."
+								placeholder={
+									membersLoading ? "Loading members..." : "Select assignee..."
+								}
+								disabled={membersLoading}
 							/>
 						</S.FormGroup>
 					</S.DialogBody>
 
 					<S.DialogFooter>
-						<S.Button variant="ghost" onClick={() => setIsUpdateOpen(false)}>
+						<S.Button
+							variant="ghost"
+							onClick={() => setIsUpdateOpen(false)}
+							disabled={updateTaskMutation.isPending}
+						>
 							Cancel
 						</S.Button>
-						<S.Button variant="primary" onClick={handleUpdate}>
-							Update Task
+						<S.Button
+							variant="primary"
+							onClick={handleUpdate}
+							disabled={updateTaskMutation.isPending}
+						>
+							{updateTaskMutation.isPending ? "Updating..." : "Update Task"}
 						</S.Button>
 					</S.DialogFooter>
 				</S.DialogContent>
@@ -939,11 +1131,20 @@ export default function TaskGroup({ onClose }: TaskGroupProps) {
 					</S.DialogBody>
 
 					<S.DialogFooter>
-						<S.Button variant="ghost" onClick={() => setIsDeleteOpen(false)}>
+						<S.Button
+							variant="ghost"
+							onClick={() => setIsDeleteOpen(false)}
+							disabled={deleteTaskMutation.isPending}
+						>
 							Cancel
 						</S.Button>
-						<S.Button variant="destructive" onClick={handleDelete}>
-							<Trash size={16} /> Delete Task
+						<S.Button
+							variant="destructive"
+							onClick={handleDelete}
+							disabled={deleteTaskMutation.isPending}
+						>
+							<Trash size={16} />{" "}
+							{deleteTaskMutation.isPending ? "Deleting..." : "Delete Task"}
 						</S.Button>
 					</S.DialogFooter>
 				</S.DialogContent>

--- a/src/layouts/MainLayout/Header/Header.styled.ts
+++ b/src/layouts/MainLayout/Header/Header.styled.ts
@@ -28,8 +28,8 @@ export const IconBtn = styled.button`
 	}
 
 	&:focus {
-	background: #eff6ff;
-	color: #6366f1;
+		background: #eff6ff;
+		color: #6366f1;
 		outline: none;
 	}
 `;
@@ -53,8 +53,8 @@ export const Tooltip = styled.span<{ visible?: boolean }>`
 	z-index: 30;
 
 	&:focus {
-	background: #eff6ff;
-	color: #6366f1;
+		background: #eff6ff;
+		color: #6366f1;
 		outline: none;
 	}
 `;

--- a/src/layouts/MainLayout/MainLayout.tsx
+++ b/src/layouts/MainLayout/MainLayout.tsx
@@ -44,7 +44,7 @@ const MainLayout = () => {
 	const [localGroups, setLocalGroups] = useState<any[]>([]);
 	const [isAdmin, setIsAdmin] = useState<boolean>(false);
 	const [showCodeListPanel, setShowCodeListPanel] = useState<boolean>(false);
-const currentUserProfile = useSelector(
+	const currentUserProfile = useSelector(
 		(state: RootState) => state.user.profile,
 	);
 	const currentUserId = currentUserProfile?.id || "";
@@ -143,7 +143,6 @@ const currentUserProfile = useSelector(
 		}
 	}, [showThreadPanel]);
 
-
 	const handleCreateThread = () => {
 		setSelectedThreadId("");
 		setShowThreadPanel(true);
@@ -173,7 +172,6 @@ const currentUserProfile = useSelector(
 		setIconSelected("");
 	};
 
-
 	const renderRightPanel = () => {
 		// Give priority to code panel when it's active so it won't be hidden by thread
 		if ((showCodeListPanel || iconSelected === "code") && !showThreadPanel) {
@@ -196,7 +194,7 @@ const currentUserProfile = useSelector(
 
 		switch (iconSelected) {
 			case "tasks":
-				return <TaskGroup onClose={handleClosePanel} />;
+				return <TaskGroup groupId={groupId} onClose={handleClosePanel} />;
 			case "code":
 				return <CodeList onClose={handleCloseCodePanel} />;
 			case "users":
@@ -207,7 +205,6 @@ const currentUserProfile = useSelector(
 				return isHalf ? null : <FriendList />;
 		}
 	};
-
 
 	return (
 		<>
@@ -258,7 +255,7 @@ const currentUserProfile = useSelector(
 						<BottomSpacer />
 					</MainLayoutContainer>
 				) : (
-					<GroupSetting setSettingSelect={setSettingSelect} isAdmin={isAdmin}/>
+					<GroupSetting setSettingSelect={setSettingSelect} isAdmin={isAdmin} />
 				)}
 			</AuthLayout>
 		</>

--- a/src/pages/Friend/Friend.tsx
+++ b/src/pages/Friend/Friend.tsx
@@ -473,7 +473,6 @@ const Friend: React.FC = () => {
 		}
 	};
 
-
 	const handleDeclineGroup = async (inviteId: string) => {
 		try {
 			setPendingGroupInvites((prev) => prev.filter((r) => r.id !== inviteId));
@@ -494,7 +493,6 @@ const Friend: React.FC = () => {
 			toast.error(`Declined fail: ${err}`);
 		}
 	};
-
 
 	const handleMenuToggle = (friendId: string, e: React.MouseEvent) => {
 		e.stopPropagation();

--- a/src/pages/Friend/Pending/Pending.tsx
+++ b/src/pages/Friend/Pending/Pending.tsx
@@ -101,7 +101,7 @@ const Pending: React.FC<Props> = ({
 		filteredFriendReceived.length > 0 ||
 		filteredFriendSent.length > 0 ||
 		filteredGroupReceived.length > 0;
-		// filteredGroupSent.length > 0;
+	// filteredGroupSent.length > 0;
 
 	return (
 		<>

--- a/src/pages/GroupSetting/GroupSetting.tsx
+++ b/src/pages/GroupSetting/GroupSetting.tsx
@@ -83,7 +83,6 @@ export const GroupSetting: React.FC<GroupSettingProps> = ({
 		},
 	];
 
-
 	const renderActiveSection = () => {
 		switch (activeSection) {
 			case "profile":
@@ -125,7 +124,7 @@ export const GroupSetting: React.FC<GroupSettingProps> = ({
 						<MenuNav>
 							{menuItems.map((item) => {
 								const Icon = item.icon;
-																const isDeleteTab = item.id === "delete";
+								const isDeleteTab = item.id === "delete";
 								return (
 									<MenuItem
 										key={item.id}

--- a/src/services/taskAPI.ts
+++ b/src/services/taskAPI.ts
@@ -1,0 +1,141 @@
+import { Task, TaskStatus } from "@/types/task";
+import { get, post, put, remove } from "./apiCaller";
+
+// --- Approximated DTOs based on controllers ---
+
+/**
+ * Request body for creating a new task.
+ * Based on `CreateTaskRequest` from `task.controller.ts`.
+ */
+export interface CreateTaskRequest {
+	name: string;
+	description?: string;
+	priority?: number;
+	status?: TaskStatus;
+	dueDate?: string;
+	assigneeId?: string;
+}
+
+/**
+ * Request body for updating an existing task.
+ * Based on `UpdateTaskRequest` from `task.controller.ts`.
+ */
+export interface UpdateTaskRequest {
+	name?: string;
+	description?: string;
+	priority?: number;
+	status?: TaskStatus;
+	dueDate?: string;
+	assigneeId?: string;
+}
+
+/**
+ * Request body for updating a task from GroupTodo component.
+ * Only includes fields that the GroupTodo component actually uses.
+ */
+export interface GroupTodoUpdateRequest {
+	name?: string;
+	description?: string;
+	priority?: number;
+	status?: TaskStatus;
+	dueDate?: string;
+}
+
+/**
+ * Query parameters for fetching a list of tasks.
+ * Based on `TaskQuery` from `task.controller.ts`.
+ */
+export interface TaskQuery {
+	page?: number;
+	limit?: number;
+	sortBy?: string;
+	sortOrder?: "ASC" | "DESC";
+	status?: TaskStatus;
+	assigneeId?: string;
+}
+
+/**
+ * Represents a task object returned from the API.
+ * Based on `TaskResponse` from `task.controller.ts`.
+ */
+export type TaskResponse = Task;
+// --- API Service Definition ---
+
+/**
+ * Creates a new task within a specific group.
+ * Corresponds to `POST /group/:groupId/task`.
+ * @param groupId - The ID of the group where the task will be created.
+ * @param data - The task data.
+ * @returns A promise that resolves to the created task.
+ */
+const createTask = (groupId: string, data: CreateTaskRequest) => {
+	return post(`/api/group/${groupId}/task`, data);
+};
+
+/**
+ * Retrieves all tasks within a specific group, with optional filtering and pagination.
+ * Corresponds to `GET /group/:groupId/task`.
+ * @param groupId - The ID of the group.
+ * @param query - The query parameters for filtering and pagination.
+ * @returns A promise that resolves to a paginated list of tasks.
+ */
+const getTasks = (groupId: string, query: TaskQuery) => {
+	return get<TaskResponse[]>(`/api/group/${groupId}/task`, query);
+};
+
+/**
+ * Retrieves a specific task by its ID.
+ * Corresponds to `GET /group/:groupId/task/:id`.
+ * @param groupId - The ID of the group.
+ * @param taskId - The ID of the task.
+ * @returns A promise that resolves to the requested task.
+ */
+const getTaskById = (groupId: string, taskId: string) => {
+	return get(`/api/group/${groupId}/task/${taskId}`);
+};
+
+/**
+ * Updates an existing task.
+ * Corresponds to `PUT /group/:groupId/task/:id`.
+ * @param groupId - The ID of the group.
+ * @param taskId - The ID of the task to update.
+ * @param data - The updated task data.
+ * @returns A promise that resolves to the updated task.
+ */
+const updateTask = (
+	groupId: string,
+	taskId: string,
+	data: UpdateTaskRequest | GroupTodoUpdateRequest,
+) => {
+	return put(`/api/group/${groupId}/task/${taskId}`, data);
+};
+
+/**
+ * Deletes a task.
+ * Corresponds to `DELETE /group/:groupId/task/:id`.
+ * @param groupId - The ID of the group.
+ * @param taskId - The ID of the task to delete.
+ * @returns A promise that resolves when the task is deleted.
+ */
+const deleteTask = (groupId: string, taskId: string) => {
+	return remove<null>(`/api/group/${groupId}/task/${taskId}`);
+};
+
+/**
+ * Retrieves all tasks for the currently authenticated user within a specific group.
+ * Corresponds to `GET /user/task/:groupId`.
+ * @param groupId - The ID of the group.
+ * @returns A promise that resolves to a list of tasks.
+ */
+const getUserTasksByGroup = (groupId: string) => {
+	return get<Task[]>(`/api/user/task/${groupId}`);
+};
+
+export const taskAPI = {
+	createTask,
+	getTasks,
+	getTaskById,
+	updateTask,
+	deleteTask,
+	getUserTasksByGroup,
+};

--- a/src/services/userGroupAPI.ts
+++ b/src/services/userGroupAPI.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { get, post, put, remove } from "./apiCaller";
 
 export interface InviteRequest {
@@ -38,7 +37,7 @@ export const updateInvitation = (
 };
 
 export const membersGroup = (groupId: string, page: number, limit: number) => {
-	return get(`/api/group/${groupId}/member?page=${page}&limit=${limit}`);
+	return get(`/api/group/${groupId}/member`, { page, limit });
 };
 
 export const deleteMemberGroup = (groupId: string, data: RemoveGrRequest) => {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,76 @@
+// This file defines the core Task types based on the backend's DTOs.
+
+// --- Placeholder Types ---
+// Ideally, these interfaces would be in their own dedicated files (e.g., src/types/user.ts)
+// but are included here for simplicity based on the request.
+
+/**
+ * Placeholder for the User object.
+ * Based on the `UserResponse` class mentioned in `TaskResponse`.
+ */
+export interface User {
+	id: string;
+	username: string;
+	email: string;
+	// Other properties like avatar, etc., would go here.
+}
+
+/**
+ * Placeholder for the Group object.
+ * Based on the `GroupResponse` class mentioned in `TaskResponse`.
+ */
+export interface Group {
+	id: string;
+	name: string;
+	// Other properties like description, members, etc., would go here.
+}
+
+// --- Enums ---
+
+/**
+ * Defines the possible statuses for a task.
+ * Matches `TaskStatusEnum` from the backend.
+ */
+export enum TaskStatus {
+	TODO = 0,
+	IN_PROGRESS = 1,
+	DONE = 2,
+}
+
+/**
+ * Defines the possible priority levels for a task.
+ * Matches `TaskPriorityEnum` from the backend.
+ */
+export enum TaskPriority {
+	LOW = 0,
+	MEDIUM = 1,
+	HIGH = 2,
+}
+
+// --- Main Task Interface ---
+
+/**
+ * Represents a Task object in the frontend application.
+ * This interface is derived from the `TaskResponse` DTO.
+ */
+export interface Task {
+	id: string;
+	name: string;
+	description: string | null;
+	status: TaskStatus;
+	priority: TaskPriority;
+	dueDate: string | null; // Dates are serialized as strings over the wire.
+	createdAt: string;
+	updatedAt: string;
+	isActive: boolean;
+
+	// Relational IDs
+	groupId: string;
+	createdBy: string;
+	assigneeId: string | null;
+
+	// Expanded relational objects
+	creator: User;
+	group: Group;
+	assignee: User | null;
+}


### PR DESCRIPTION
Add taskAPI service and Task types; refactor GroupTodo and TaskGroup to use react-query for fetching and mutations, add loading/error states, use membersGroup for assignee options, and pass groupId from MainLayout.